### PR TITLE
Implement ryo-address-validator tool

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -101,10 +101,9 @@ Explanation for each field:
        be ignored and this tool will be used instead. The tool will check
        that the address is both valid and on the same network (testnet,
        mainnet, etc). Set to false to disable this check and use default
-       allowedMinerAddressPrefixes method.
-       Example: "/opt/ryo-currency/build/release/bin/ryo-address-validator"
-       */
-    "addressValidatorBin": "/opt/ryo-currency/build/release/bin/ryo-address-validator",
+       allowedMinerAddressPrefixes method. Copy the binary to the bin
+       folder within this pool directory, or set an absolute path. */
+    "addressValidatorBin": "bin/ryo-address-validator",
 
     /* These cryptonote address prefixes are used to check whether the
        miner supplied a valid address. The values below are for sumokoin

--- a/USAGE.md
+++ b/USAGE.md
@@ -96,6 +96,16 @@ Explanation for each field:
     /* How many seconds until we consider a miner disconnected. */
     "minerTimeout": 900,
 
+    /* Optionally set the path to the address validator tool included
+       with the coin's release. If set, allowedMinerAddressPrefixes will
+       be ignored and this tool will be used instead. The tool will check
+       that the address is both valid and on the same network (testnet,
+       mainnet, etc). Set to false to disable this check and use default
+       allowedMinerAddressPrefixes method.
+       Example: "/opt/ryo-currency/build/release/bin/ryo-address-validator"
+       */
+    "addressValidatorBin": "/opt/ryo-currency/build/release/bin/ryo-address-validator",
+
     /* These cryptonote address prefixes are used to check whether the
        miner supplied a valid address. The values below are for sumokoin
        wallet and subaddresses. If you use a different coin than you must

--- a/config_ryo.json
+++ b/config_ryo.json
@@ -24,6 +24,7 @@
         "minerTimeout": 1800,
         "sslKey": "key.pem",
         "sslCert": "cert.pem",
+	"addressValidatorBin": false,
         "allowedMinerAddressPrefixes": [
           "2864026", "536986"
         ],

--- a/lib/api.js
+++ b/lib/api.js
@@ -705,7 +705,8 @@ function handleAdminUsers(response){
                 var workersData = {};
                 var addressLength = config.poolServer.poolAddress.length;
                 for(var i in redisData) {
-                    var address = workerKeys[i].substr(-addressLength);
+                    //var address = workerKeys[i].substr(-addressLength);
+		    var address = workerKeys[i].substr(workerKeys[i].lastIndexOf(':')+1);
                     var data = redisData[i];
                     workersData[address] = {
                         pending: data[0],

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -4,11 +4,15 @@ var crypto = require('crypto');
 
 var async = require('async');
 var bignum = require('bignum');
-var multiHashing = require('multi-hashing');
+var base58 = require('base58-native');
 var cnUtil = require('cryptonote-util');
+var multiHashing = require('multi-hashing');
 
 // Must exactly be 8 hex chars, already lowercased before test
 var noncePattern = new RegExp("^[0-9a-f]{8}$");
+
+// Used for calling the address validator
+var execSync = require('child_process').execSync;
 
 //SSL for claymore
 var tls = require('tls');
@@ -589,11 +593,30 @@ function handleMinerMethod(method, params, ip, portData, sendReply, pushMessage)
                 }
             }
 
-            // Check that the address prefix is sane.
-            var addressPrefix = cnUtil.address_decode(new Buffer(login)).toString();
-            if (config.poolServer.allowedMinerAddressPrefixes.indexOf(addressPrefix) == -1) {
-                sendReply('invalid address used');
-                return;
+            if(config.poolServer.addressValidatorBin != null && fs.existsSync(config.poolServer.addressValidatorBin)) {
+
+                var sanitized_user = base58.encode(base58.decode(login));
+                var sanitized_payout = base58.encode(base58.decode(config.poolServer.poolAddress));
+
+                var command = config.poolServer.addressValidatorBin+' '+sanitized_user+' '+sanitized_payout;
+
+                var output = execSync(command).toString()
+                var info = JSON.parse(output.replace(/(['"])?([a-zA-Z0-9_]+)(['"])?:/g, '"$2":'));
+
+                if(!info[0].valid || info[0].network != info[1].network) {
+                    sendReply('invalid address used');
+                    return;
+                }
+
+            } else {
+
+                // Check that the address prefix is sane.
+                var addressPrefix = cnUtil.address_decode(new Buffer(login)).toString();
+                if (config.poolServer.allowedMinerAddressPrefixes.indexOf(addressPrefix) == -1) {
+                    sendReply('invalid address used');
+                    return;
+                }
+
             }
 
             var minerId = utils.uid();

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -593,7 +593,7 @@ function handleMinerMethod(method, params, ip, portData, sendReply, pushMessage)
                 }
             }
 
-            if(config.poolServer.addressValidatorBin != null && fs.existsSync(config.poolServer.addressValidatorBin)) {
+            if(config.poolServer.addressValidatorBin != false && fs.existsSync(config.poolServer.addressValidatorBin)) {
 
                 var sanitized_user = base58.encode(base58.decode(login));
                 var sanitized_payout = base58.encode(base58.decode(config.poolServer.poolAddress));


### PR DESCRIPTION
Code to implement the `ryo-address-validator` tool shipped with ryo-currency for checking if an address is valid. It will check both that the miner's address is valid as well as the miner's address is on the same network that the pool is on (testnet, mainnet, etc)

Usage is optional and the prefix check can still be used instead.